### PR TITLE
Add links to the actual KCD Suisse Romande locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,23 @@
 # KCD Suisse Romande 2025
 
+A sister-repository for public materials and content related to the KCD Suisse Romande.
+
+Most of the content lives here:
+
+- [Conference site](https://kcd.cloud-native-romandy.ch) - on community.cncf.io
+- [Conference Program](https://sessionize.com/view/rlq5we3p/GridSmart) - on Sessionize
+- [Association Website](https://cloud-native-romandy.ch) - additional resources and assets [GitHub](https://github.com/cloud-native-suisse-romande/association-website)
+
+## Chat
+
+* Public: `#kcd-suisse-romande` on the [CNCF Slack](https://slack.cncf.io/)
+
+## Assets
+
 Public content and assets for KCD Suisse Romande 2025.
+
+> **NOTE:** In fact, we have a lot of content. It mostly lives on Google Drives as of now.
+> Ping the team on the `#kcd-suisse-romande` channel if you need any materials for promotion that are missing here
 
 ## References
 


### PR DESCRIPTION
This old repo is somewhat empty as the work is going elsewhere for now. I updated the README with the pointers a bit